### PR TITLE
fix: amounts were group amounts

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -10,8 +10,11 @@ describe('parse reimbursements', () => {
   it('should parse reimbursements correctly', () => {
     const reimbursements = parseRemboursements($, () => {})
     expect(reimbursements.length).toBe(92)
+    expect(reimbursements[70].amount).toBe(34.5)
+    expect(reimbursements[70].groupAmount).toBe(111)
     expect(reimbursements[0]).toEqual({
-      "amount": 2.19,
+      "amount": 0.36,
+      "groupAmount": 2.19,
       "beneficiary": "Raphael THIRIOT",
       "date": new Date("2018-03-07T23:00:00.000Z"),
       "filename": "20180308_528117465_R18065200942444511_malakoff_mederic.pdf",
@@ -26,12 +29,11 @@ describe('parse reimbursements', () => {
       "socialSecurityRefund": 0.66,
       "subtype": "Honoraires de dispensation conditionnement normal pharmacie 65%",
       "type": "health_costs",
-      "vendor": "Malakoff Mederic",
-      "groupAmount": 8.76
+      "vendor": "Malakoff Mederic"
     })
     expect(reimbursements[10]).toEqual({
-      "groupAmount": 14.16,
-      "amount": 3.54,
+      "groupAmount": 3.54,
+      "amount": 0.81,
       "beneficiary": "Raphael THIRIOT",
       "date": new Date("2018-02-06T23:00:00.000Z"),
       "filename": "20180207_528117465_R18037202299646947_malakoff_mederic.pdf",
@@ -48,5 +50,6 @@ describe('parse reimbursements', () => {
       "type": "health_costs",
       "vendor": "Malakoff Mederic",
     })
+
   })
 })

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -15,11 +15,7 @@ function parseRemboursements($, getRequestOptions) {
     const $this = $(this)
     const $header = $this.find('.headerRemboursements')
 
-    const { amount, date, isThirdPartyPayer, fileurl, idReimbursement } = scrape($header, {
-      amount: {
-        sel: '.montant',
-        parse: convertAmount
-      },
+    const { date, isThirdPartyPayer, fileurl, idReimbursement } = scrape($header, {
       date: {
         sel: '#datePaiement',
         fn: node => moment(node.val(), 'x')
@@ -41,6 +37,7 @@ function parseRemboursements($, getRequestOptions) {
 
     let beneficiary = null
     const $subrows = $this.find('> .body tbody tr')
+
     $subrows.each(function() {
       const $this = $(this)
       const data = $this
@@ -51,6 +48,16 @@ function parseRemboursements($, getRequestOptions) {
             .trim()
         })
         .get()
+
+      const { amount } = scrape($this, {
+        amount: {
+          sel: 'td:nth-child(5),td:nth-child(6)',
+          fn: nodes => sumBy(
+            nodes,
+            node => convertAmount($(node).text().trim())
+          )
+        }
+      })
 
       if (data.length === 1) {
         // Beneficiary line


### PR DESCRIPTION
Amounts were in fact groupAmounts. Since 1 bill is yielded for each row from
the malakoff mederic website, we should just sum malakoff mederic reimbursements
to get the amount.

The amount above each table is the groupAmount.

In the example below, the groupAmount is the same as the amount since there is only 1 row.

![image](https://user-images.githubusercontent.com/465582/37718707-a1507b3a-2d23-11e8-85d8-b00914c0d19a.png)
